### PR TITLE
ghostty: make Cmd+V paste work in Supacode

### DIFF
--- a/dotfile_templates/ghostty/config
+++ b/dotfile_templates/ghostty/config
@@ -66,6 +66,11 @@ scrollback-limit = 10485760
 # -----------------------------------------------------------------------------
 copy-on-select = clipboard
 
+# Cmd+V paste: Ghostty's paste-protection prompt is suppressed inside Supacode,
+# so pastes with newlines/control chars silently do nothing. Disable it so
+# Cmd+V pastes directly (the super+v keybind is set in the Keybindings section).
+clipboard-paste-protection = false
+
 # -----------------------------------------------------------------------------
 # URLs
 # -----------------------------------------------------------------------------
@@ -84,6 +89,9 @@ quit-after-last-window-closed = true
 # Defaults already handle: Cmd+T (tab), Cmd+W (close), Cmd+K (clear),
 # Cmd+N (new window), Cmd+1-9 (tab switching), Cmd+Enter (fullscreen)
 # -----------------------------------------------------------------------------
+
+# Paste (Cmd+V) — explicit so it works in Supacode's embedded Ghostty
+keybind = super+v=paste_from_clipboard
 
 # Split panes (Warp: Cmd+D → right, Cmd+Shift+D → down)
 keybind = super+d=new_split:right


### PR DESCRIPTION
## Problem
Cmd+V doesn't paste in Supacode (which embeds Ghostty and reads `~/.config/ghostty/config`). Supacode isn't stealing Cmd+V at the app level (no keyCode-9 override in its shortcuts) — Ghostty's `clipboard-paste-protection` confirm dialog is suppressed inside Supacode, so pastes of multiline/control content silently no-op.

## Fix (`dotfile_templates/ghostty/config`)
- `clipboard-paste-protection = false` — skip the suppressed confirm prompt
- `keybind = super+v=paste_from_clipboard` — bind Cmd+V explicitly

## Verify
- `ghostty +validate-config` → exit 0
- Live via stow symlink at `~/.config/ghostty/config`
- **User test:** reload Supacode config (restart Supacode, or new window) → Cmd+V pastes

Note: `paste-protection` off means multiline pastes run without the safety confirm — intended, matches Warp/other-terminal behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)